### PR TITLE
Adds support for the PJ2-3B remote

### DIFF
--- a/accessory.js
+++ b/accessory.js
@@ -18,7 +18,8 @@ const types = {
   "scene": ['8', '9', '10', '11'],
   "simple": ['2', '4'],
   "dimmer": ['2', '5', '6', '4'],
-  "favorite": ['2', '5', '3', '6', '4']
+  "favorite": ['2', '5', '3', '6', '4'],
+  "PJ2-3B": ['2', '3', '4']
 }
 
 let Accessory, Characteristic, Service;


### PR DESCRIPTION
Added the missing PJ2-3B remote. This remote is rare but is a Caseta remote, you can find more information on all the different remotes @ https://www.lutron.com/TechnicalDocumentLibrary/369453_Pico%20spec%20submittal.pdf